### PR TITLE
fix(omg-cli): fix issue where cli tries to remove a non running container

### DIFF
--- a/packages/omg/src/cli/Cli.ts
+++ b/packages/omg/src/cli/Cli.ts
@@ -367,25 +367,25 @@ export default class Cli {
     // if (!(await this._run.isRunning())) {
     if (isHealthy === false) {
       // 2. health check
-      if (options.raw) {
-        utils.error('Health check failed')
-      } else {
+      if (!options.raw) {
         spinner.fail('Health check failed')
       }
       // utils.error(`  Docker logs:\n${await this._run.getLogs()}`)
       if (this.microservice.health) {
         // Temporary, remove when health is mandatory
         if (this._run.constructor.name !== 'EventRun') {
-          if (!options.raw) {
-            spinner = ora.start(
-              `Stopping Docker container: ${this.startedID.substring(0, 12)}`
-            )
-          }
-          const stoppedID = await this._run.stopService()
-          if (!options.raw) {
-            spinner.succeed(
-              `Stopped Docker container: ${stoppedID.substring(0, 12)}`
-            )
+          if (await this._run.isRunning()) {
+            if (!options.raw) {
+              spinner = ora.start(
+                `Stopping Docker container: ${this.startedID.substring(0, 12)}`
+              )
+            }
+            const stoppedID = await this._run.stopService()
+            if (!options.raw) {
+              spinner.succeed(
+                `Stopped Docker container: ${stoppedID.substring(0, 12)}`
+              )
+            }
           }
         }
         process.exit(1)


### PR DESCRIPTION
Fixes #247 

When health check fails because the container failed, the cli should not try to remove it (if it s
not running)