### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $> lerna run coverage
 ## Publish all packages that need to be published
 
 ```
-$> lerna run publish
+$> yarn run publish
 ```
 
 ## Automatic version bump

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Thanks to lerna you can run commands available in all packages using `lerna run 
 
 ```bash
 # Install lerna
-$> npm install
+$> yarn
 
 # Install the packages dependencies
-$> npm run bootstrap
+$> yarn bootstrap
+
+# Builds package sources for when you execute
+$> yarn build
 ```
 
 ## Compiles and minifies all packages for production
@@ -44,7 +47,7 @@ $> lerna run coverage
 ## Publish all packages that need to be published
 
 ```
-$> npm run publish
+$> lerna run publish
 ```
 
 ## Automatic version bump
@@ -61,6 +64,5 @@ If you want to manually bump the packages version, you can use `lerna version`.
 ## Make an alias
 
 ```bash
-# Making an alias is usefull to prevent using the real `omg` package when installed locally
-$> alias omg=~/path/to/omg/omg
+$> yarn link-bin
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "yarn": "^1.16.0"
   },
   "scripts": {
+    "link-bin": "(cd packages/omg; yarn link)",
     "bootstrap": "lerna bootstrap --npm-client=yarn",
     "lint": "lerna run --parallel lint",
     "test": "lerna run --parallel test",


### PR DESCRIPTION
Replaces npm with `yarn` since we have a yarn lockfile and we tell lerna to use yarn as the client