### PR TITLE
Fix support for form-data content type

### DIFF
--- a/packages/omg-validate/src/schema/schemas/http.ts
+++ b/packages/omg-validate/src/schema/schemas/http.ts
@@ -14,7 +14,7 @@ export default {
     },
     contentType: {
       type: 'string',
-      enum: ['application/json', 'application/x-www-form-urlencoded'],
+      enum: ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data'],
     },
   },
   required: ['method', 'port', 'path'],

--- a/packages/omg/src/commands/run/HttpRun.ts
+++ b/packages/omg/src/commands/run/HttpRun.ts
@@ -68,7 +68,10 @@ export default class HttpRun extends Run {
         case 'multipart/form-data': {
           const formData = this.jsonToFormData(httpData.jsonData)
           opts.body = formData.getBuffer()
-          opts.headers = formData.getHeaders()
+          opts.headers = {
+            ...formData.getHeaders(),
+            'content-length': opts.body.length,
+          }
           break
         }
         case 'application/x-www-form-urlencoded':

--- a/packages/omg/src/commands/run/HttpRun.ts
+++ b/packages/omg/src/commands/run/HttpRun.ts
@@ -58,7 +58,6 @@ export default class HttpRun extends Run {
       uri: string
       body?: string
       headers?: any
-      formData?: FormData
     } = {
       method: this.action.http.method.toUpperCase(),
       resolveWithFullResponse: tmpRetryExec,
@@ -67,8 +66,9 @@ export default class HttpRun extends Run {
     if (this.action.http.method === 'post' || this.action.http.method === 'put') {
       switch (this.action.http.contentType) {
         case 'multipart/form-data': {
-          opts.formData = this.jsonToFormData(httpData.jsonData)
-          opts.headers = opts.formData.getHeaders()
+          const formData = this.jsonToFormData(httpData.jsonData)
+          opts.body = formData.getBuffer()
+          opts.headers = formData.getHeaders()
           break
         }
         case 'application/x-www-form-urlencoded':


### PR DESCRIPTION
Fixes #261

We were passing our json-converted-FormData instance as `opts.formData` to `request`, but `request` expects it to be a raw object. If we do send in a raw-object to it, we won't be able to specify content-length, which we want to do.

So instead now we convert JSON to form-data and then get it's raw buffer to send as request payload